### PR TITLE
Updates to the README and support for a Durable subscription

### DIFF
--- a/JobLogEventsDirCreator/src/main/java/net/wasdev/jobLogEventDirCreator/JobLogEventsSubscriber.java
+++ b/JobLogEventsDirCreator/src/main/java/net/wasdev/jobLogEventDirCreator/JobLogEventsSubscriber.java
@@ -24,6 +24,7 @@ import java.text.SimpleDateFormat;
 import java.util.Date;
 
 import javax.ejb.MessageDriven;
+import javax.ejb.ActivationConfigProperty;
 import javax.jms.JMSException;
 import javax.jms.Message;
 import javax.jms.MessageListener;
@@ -33,9 +34,20 @@ import javax.json.JsonArray;
 import javax.json.JsonObject;
 
 /**
- * An MDB to subscribe to job log events and create the job log directory structure
+ * An MDB to subscribe to job log events and create the job log directory structure.
+ * Change the subscriptionDurability to "Durable" for a durable subscription.
  */
-@MessageDriven
+@MessageDriven(
+    activationConfig = { 
+    @ActivationConfigProperty(propertyName = "subscriptionName", 
+            propertyValue = "JOBLOGS"),
+    @ActivationConfigProperty(propertyName = "clientId", 
+            propertyValue = "LOGMON"),                            
+    @ActivationConfigProperty(propertyName = "subscriptionDurability", 
+            propertyValue = "NonDurable")
+    }            
+)
+
 public class JobLogEventsSubscriber implements MessageListener {
 
     @Override

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ The steps below assume you are using two (or three) Liberty servers.  One server
 
 **3.) If using the WebSphere integrated messaging engine, configure the wasJmsServer-1.0 feature as well as the following:**
 
-'''xml
+```xml
 <wasJmsEndpoint host="*" 
 		  wasJmsPort="7280" 
 		  wasJmsSSLPort="7290" 
@@ -31,11 +31,11 @@ The steps below assume you are using two (or three) Liberty servers.  One server
 		forceReliability="ReliablePersistent" 
 		receiveAllowed="true"/>
 </messagingEngine>    
-'''
+```
 
 **4.)  Configure a server to run your batch job.  The server must also be configured to publish batch event messages, which requires the batchManagement-1.0 as well as the wasJmsClient-2.0 features. Configuration to publish to the WebSphere messaging engine described above would look like this:**
 
-'''xml
+```xml
     <batchJmsEvents connectionFactoryRef="batchConnectionFactory" />
     
     <jmsConnectionFactory id="batchConnectionFactory" jndiName="jms/batch/connectionFactory">
@@ -43,8 +43,7 @@ The steps below assume you are using two (or three) Liberty servers.  One server
        remoteServerAddress="localhost:7280:BootstrapBasicMessaging"
        />
     </jmsConnectionFactory>
-
-'''
+```
 
 If using MQ as the messaging engine, use properties.wmqJms with appropriate values.  The first document link above has samples.**
 
@@ -63,11 +62,12 @@ If using MQ as the messaging engine, use properties.wmqJms with appropriate valu
 		/>
 </jmsActivationSpec>
 ```
+
 __Note:__ This allows the MDB application to receive all the batch job log event messages, which contain the job log contents.
 
 If using MQ for the messaging engine the updates will look more like this:**
 
-'''xml
+```xml
 <jmsTopic id="JobLogEventTopic" jndiName="jms/batch/batchJobTopic">
  <properties.wmqJms
    baseTopicName=“batch/jobs/execution/jobLogPart”
@@ -84,7 +84,7 @@ If using MQ for the messaging engine the updates will look more like this:**
       hostName=“wg31.washington.ibm.com”
       port=“1414" />
 </jmsActivationSpec>
-'''
+```
 
 __Note:__ For a durable subscription a queue is required to hold the messages while the subscriber is not available.  That queue name must start 'SYSTEM.JMS'.  There is a default queue for this but we've created a different one here.**
 

--- a/README.md
+++ b/README.md
@@ -9,16 +9,48 @@ It is a MDB application that demos the job log as an event functionality of the 
 * [A document](http://www.ibm.com/support/knowledgecenter/en/was_beta_liberty/com.ibm.websphere.wlp.nd.multiplatform.doc/ae/twlp_batch_monitoring.html) discussing how to enable batch job event publishing for Java Batch in WebSphere
 * [A document](http://www.ibm.com/support/knowledgecenter/en/was_beta_liberty/com.ibm.websphere.wlp.nd.multiplatform.doc/ae/rwlp_batch_view_joblog.html) going into more detail about job logging for Java Batch in WebSphere
 
+The steps below assume you are using two (or three) Liberty servers.  One server actually runs the batch job.  A second server hosts the MDB that captures the job log.  A third server may be configured to host the WebSphere messaging engine (or you can use MQ).  This can all be combined into fewer servers, but the separation seemed to make it clearer what is going on.
+
 ## Steps to set up and use this sample app
 
 **1.) Download the pre-built WAR file or build the WAR file using the source code and maven**
 
 **2.) Place the WAR file in the desired server's "dropins" directory**
 
-**3.) Update the server.xml file for the chosen server to include the following:**
+**3.) If using the WebSphere integrated messaging engine, configure the wasJmsServer-1.0 feature as well as the following:**
+
+'''xml
+<wasJmsEndpoint host="*" 
+		  wasJmsPort="7280" 
+		  wasJmsSSLPort="7290" 
+		  enabled="true"> 
+</wasJmsEndpoint>
+
+<messagingEngine>
+	<queue id="batchLibertyQueue" 
+		forceReliability="ReliablePersistent" 
+		receiveAllowed="true"/>
+</messagingEngine>    
+'''
+
+**4.)  Configure a server to run your batch job.  The server must also be configured to publish batch event messages, which requires the batchManagement-1.0 as well as the wasJmsClient-2.0 features. Configuration to publish to the WebSphere messaging engine described above would look like this:**
+
+'''xml
+    <batchJmsEvents connectionFactoryRef="batchConnectionFactory" />
+    
+    <jmsConnectionFactory id="batchConnectionFactory" jndiName="jms/batch/connectionFactory">
+       <properties.wasJms
+       remoteServerAddress="localhost:7280:BootstrapBasicMessaging"
+       />
+    </jmsConnectionFactory>
+
+'''
+
+If using MQ as the messaging engine, use properties.wmqJms with appropriate values.  The first document link above has samples.**
+
+**5.)  Configure a server to host the MDB and subscribe to batch event topic tree.  It will need to enable the wasJmsClient-2.0 feature.  If using the WebSphere messaging engine it will look like this:**
 
 ```xml
-<!--  This is used by the MDB application activation spec to filter for topics in the topic tree. -->
 <jmsTopic id="JobLogEventTopic" jndiName="jms/batch/batchJobTopic">
 	<properties.wasJms topicName="batch//jobs//execution//jobLogPart//." />
 </jmsTopic>
@@ -26,14 +58,39 @@ It is a MDB application that demos the job log as an event functionality of the 
 <!-- The MDB application to create job log directories from job log events-->
 <jmsActivationSpec id="JobLogEventsDirCreator-1.0/JobLogEventsSubscriber">
 	<properties.wasJms
-		destinationRef="JobLogEventTopic" destinationType="javax.jms.Topic" />
+		destinationRef="JobLogEventTopic" destinationType="javax.jms.Topic" 
+		remoteServerAddress="localhost:7280:BootstrapBasicMessaging"
+		/>
 </jmsActivationSpec>
 ```
 __Note:__ This allows the MDB application to receive all the batch job log event messages, which contain the job log contents.
 
-**4.) Either start or restart the updated server.**
+If using MQ for the messaging engine the updates will look more like this:**
 
-Now the MDB application will create a directory called "JobLogEvents" under the configured server's main directory. It will contain all of the batch job log parts from all servers that have batch events enabled and produce job log parts.
+'''xml
+<jmsTopic id="JobLogEventTopic" jndiName="jms/batch/batchJobTopic">
+ <properties.wmqJms
+   baseTopicName=“batch/jobs/execution/jobLogPart”
+   brokerDurSubQueue=“SYSTEM.JMS.D.JSRMON” />
+</jmsTopic>
+
+<jmsActivationSpec id=“JobLogEventsDirCreator-1.0/JobLogEventsSubscriber”>
+     <properties.wmqJms
+      destinationRef=“JobLogEventTopic”
+      destinationType=“javax.jms.Topic”
+      transportType=“CLIENT”
+      channel=“SYSTEM.DEF.SVRCONN”
+      queueManager=“MQS1"
+      hostName=“wg31.washington.ibm.com”
+      port=“1414" />
+</jmsActivationSpec>
+'''
+
+__Note:__ For a durable subscription a queue is required to hold the messages while the subscriber is not available.  That queue name must start 'SYSTEM.JMS'.  There is a default queue for this but we've created a different one here.**
+
+**6.) Start the required servers and submit your batch job.**
+
+Now the MDB application will create a directory called "JobLogEvents" under the configured server's main directory. It will contain all of the batch job log parts from all servers that have batch events enabled and produce job log parts.**
 
 **Example directory structure created:**
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ The steps below assume you are using two (or three) Liberty servers.  One server
     </jmsConnectionFactory>
 ```
 
-If using MQ as the messaging engine, use properties.wmqJms with appropriate values.  The first document link above has samples.**
+If using MQ as the messaging engine, use properties.wmqJms with appropriate values.  The first document link above has samples.
 
 **5.)  Configure a server to host the MDB and subscribe to batch event topic tree.  It will need to enable the wasJmsClient-2.0 feature.  If using the WebSphere messaging engine it will look like this:**
 
@@ -65,7 +65,7 @@ If using MQ as the messaging engine, use properties.wmqJms with appropriate valu
 
 __Note:__ This allows the MDB application to receive all the batch job log event messages, which contain the job log contents.
 
-If using MQ for the messaging engine the updates will look more like this:**
+If using MQ for the messaging engine the updates will look more like this:
 
 ```xml
 <jmsTopic id="JobLogEventTopic" jndiName="jms/batch/batchJobTopic">
@@ -86,11 +86,11 @@ If using MQ for the messaging engine the updates will look more like this:**
 </jmsActivationSpec>
 ```
 
-__Note:__ For a durable subscription a queue is required to hold the messages while the subscriber is not available.  That queue name must start 'SYSTEM.JMS'.  There is a default queue for this but we've created a different one here.**
+__Note:__ For a durable subscription a queue is required to hold the messages while the subscriber is not available.  That queue name must start 'SYSTEM.JMS'.  There is a default queue for this but we've created a different one here.  You'll need to change the annotations in the code to indicate you want a Durable subscription.
 
 **6.) Start the required servers and submit your batch job.**
 
-Now the MDB application will create a directory called "JobLogEvents" under the configured server's main directory. It will contain all of the batch job log parts from all servers that have batch events enabled and produce job log parts.**
+Now the MDB application will create a directory called "JobLogEvents" under the configured server's main directory. It will contain all of the batch job log parts from all servers that have batch events enabled and produce job log parts.
 
 **Example directory structure created:**
 


### PR DESCRIPTION
I added text to the README to show more details of the configuration, including some notes about required features and how to use MQ instead of the WebSphere internal messaging engine.  I also updated the Java code with additional annotations to allow you to have a durable subscription so you won't miss joblog messages if the MDB-hosting server is down while jobs are running.  This isn't the default behavior, but it should be clear from the comments how to do that if you want to.